### PR TITLE
Fixed parsing issue in the decoder when maxHeaderTableSizeChangeRequired...

### DIFF
--- a/src/main/java/com/twitter/hpack/Decoder.java
+++ b/src/main/java/com/twitter/hpack/Decoder.java
@@ -91,7 +91,7 @@ public final class Decoder {
       switch(state) {
       case READ_HEADER_REPRESENTATION:
         byte b = (byte) in.read();
-        if (maxHeaderTableSizeChangeRequired && (b & 0xF0) != 0x20) {
+        if (maxHeaderTableSizeChangeRequired && (b & 0xE0) != 0x20) {
           // Encoder MUST signal maximum header table size change
           throw MAX_HEADER_TABLE_SIZE_CHANGE_REQUIRED;
         }


### PR DESCRIPTION
When "max header table size" is set, the first byte is typically 0x3f (0x20 | 0x1f), assuming the new value needs more than 5 bits. The test in incorrect, and the "max header table size change required" exception gets thrown when it should not. This causes some issues in netty 4.1+ when the server sets the max header table size in settings.
