### PR TITLE
Fix typo in addHeader javadoc

### DIFF
--- a/hpack/src/main/java/com/twitter/hpack/HeaderListener.java
+++ b/hpack/src/main/java/com/twitter/hpack/HeaderListener.java
@@ -18,7 +18,7 @@ package com.twitter.hpack;
 public interface HeaderListener {
 
   /**
-   * emitHeader is called by the decoder during header field emission.
+   * addHeader is called by the decoder during header field emission.
    * The name and value byte arrays must not be modified.
    */
   public void addHeader(byte[] name, byte[] value, boolean sensitive);


### PR DESCRIPTION
Javadoc refers to the old name of this method ( https://github.com/twitter/hpack/commit/84e3438ae60efad587c7058c87b04064d7d6a536#diff-fff74a721c5de5583baccc97a5abf7eeR24 ),
not a biggie but figured why not fix it since I spotted it.
